### PR TITLE
AWS-Region option added

### DIFF
--- a/check_sqs_queue.conf
+++ b/check_sqs_queue.conf
@@ -1,11 +1,12 @@
 # When setting the options below, don't forget to uncomment them
 
 [AWS]
-#aws_access_key_id = 
-#aws_secret_access_key = 
+#aws_access_key_id =
+#aws_secret_access_key =
+#aws_region =
 
 [SMTP]
-#smtp_server = 
-#smtp_port = 
-#smtp_user = 
-#smtp_password = 
+#smtp_server =
+#smtp_port =
+#smtp_user =
+#smtp_password =


### PR DESCRIPTION
Added to config (.ini) parameter AWS_REGION to be able to choose a
different AWS region.
Necessary code changes to use this parameter are included as well.

the sqs_connection() call had to be changed to a
boto.sqs.connecto_to_region() call in case a specific AWS region is defined.
